### PR TITLE
feat: configure github-pr-author agent to always create draft PRs

### DIFF
--- a/agents/github-pr-author.md
+++ b/agents/github-pr-author.md
@@ -45,6 +45,10 @@ When creating a pull request, you will:
    - Check that the title and description are consistent with each other
    - Confirm that any required checkboxes or fields are properly filled
 
+6. **Create as Draft**:
+   - Always create pull requests as drafts using the `--draft` flag
+   - This allows for review and refinement before marking as ready for review
+
 You will be thorough in your analysis but concise in your writing. Your goal is to create a PR that requires minimal back-and-forth with reviewers because it provides all necessary context upfront. Always prioritize accuracy and completeness over brevity when describing changes that could impact other parts of the system.
 
 If you cannot access certain information (like recent PRs or templates), clearly state what you're missing and provide the best PR you can with available information, following general best practices for PR structure and content.


### PR DESCRIPTION
## Summary

Update the github-pr-author agent configuration to always create pull requests as drafts by default. This change adds a new step in the PR creation process that ensures all PRs are created with the `--draft` flag.

## Changes Made

- Added new section "6. Create as Draft" to `/Users/elioshinsky/.claude/agents/github-pr-author.md`
- Specified that the agent should always use the `--draft` flag when creating PRs
- Added rationale that draft PRs allow for review and refinement before marking as ready

## Rationale

Creating PRs as drafts by default provides several benefits:
- Allows authors to review their own work before requesting formal review
- Prevents accidental early notifications to reviewers for incomplete work  
- Enables iterative refinement of PR content and commits
- Follows best practices for collaborative development workflows

## Testing

- Verified the agent configuration file syntax and formatting
- Confirmed the new instruction integrates properly with existing workflow steps